### PR TITLE
Support using VIP Enterprise Search with ES container

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -48,6 +48,11 @@ x-php: &php
     XDEBUG_CONFIG: idekey=${HTTP_HOST:-default} remote_host=${XDEBUG_REMOTE_HOST:-host.docker.internal}
     # Pass through subdomains configuration into PHP
     SUBDOMAIN_INSTALL: ${SUBDOMAIN_INSTALL}
+    # Set up VIP specific constants to use Enterprise Search
+    VIP_ELASTICSEARCH_ENDPOINT: 'http://elasticsearch:9200'
+    VIP_ELASTICSEARCH_USERNAME: elastic
+    VIP_ELASTICSEARCH_PASSWORD: elasticadmin
+    FILES_CLIENT_SITE_ID: 123
 
 x-analytics: &analytics
   ports:
@@ -109,7 +114,7 @@ services:
       AWS_REGION: us-east-1
 
   elasticsearch:
-    image: humanmade/altis-local-server-elasticsearch:3.0.0
+    image: humanmade/altis-local-server-elasticsearch:4.1.0
     ulimits:
       memlock:
         soft: -1

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -36,6 +36,12 @@ function bootstrap() {
 	define( 'ELASTICSEARCH_HOST', getenv( 'ELASTICSEARCH_HOST' ) );
 	define( 'ELASTICSEARCH_PORT', getenv( 'ELASTICSEARCH_PORT' ) );
 
+	// Set up VIP specific constants to use Enterprise Search.
+	define( 'VIP_ELASTICSEARCH_ENDPOINTS', [ getenv( 'VIP_ELASTICSEARCH_ENDPOINT' ) ] );
+	define( 'VIP_ELASTICSEARCH_USERNAME', getenv( 'VIP_ELASTICSEARCH_USERNAME' ) );
+	define( 'VIP_ELASTICSEARCH_PASSWORD', getenv( 'VIP_ELASTICSEARCH_PASSWORD' ) );
+	define( 'FILES_CLIENT_SITE_ID', getenv( 'FILES_CLIENT_SITE_ID' ) ); // Mocks the site id on VIP.
+
 	// Set "development" unless overridden in `local-config.php`.
 	defined( 'WP_ENVIRONMENT_TYPE' ) or define( 'WP_ENVIRONMENT_TYPE', 'local' );
 


### PR DESCRIPTION
Update to ES 7.10.2 to support using VIP’s Enterprise Search and Kibana 7.10 to support the new ES version. Add the required constants to enable the enterprise search logic.