### PR TITLE
Allow PHP 8.0 and (conditionally) replace Memcached with Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Fill out your project's `composer.json` to define the project name, domain, and 
       "name": "test-vip",
       "domain": "text.local",
       "subdomains": true,
+			"db-image": "biarms/mysql:5.7"
       "sites": {
         "subdomain": "Subsite Name"
       }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Fill out your project's `composer.json` to define the project name, domain, and 
       "name": "test-vip",
       "domain": "text.local",
       "subdomains": true,
-			"db-image": "biarms/mysql:5.7"
+      "db-image": "biarms/mysql:5.7"
       "sites": {
         "subdomain": "Subsite Name"
       }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
 		"php": ">=7.1",
 		"composer-plugin-api": "^2.0",
 		"humanmade/wordpress-pecl-memcached-object-cache": "^2.1",
-		"symfony/yaml": "~5.3.6"
+		"symfony/yaml": "~5.3.6",
+		"humanmade/wp-redis": "^1.1"
 	},
 	"extra": {
 		"class": "HM\\Local_VIP\\Composer\\Plugin"

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -126,7 +126,6 @@ EOT
 			'xdebug' => 'off',
 			'mutagen' => 'off',
 			'secure' => $this->get_composer_config()['secure'] ?? true,
-			'db-image' => $this->get_composer_config()['db-image'] ?? 'biarms/mysql:5.7',
 		];
 
 		// If Xdebug switch is passed add to docker compose args.

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -126,6 +126,7 @@ EOT
 			'xdebug' => 'off',
 			'mutagen' => 'off',
 			'secure' => $this->get_composer_config()['secure'] ?? true,
+			'db-image' => $this->get_composer_config()['db-image'] ?? 'biarms/mysql:5.7',
 		];
 
 		// If Xdebug switch is passed add to docker compose args.

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -506,7 +506,7 @@ class Docker_Compose_Generator {
 		$php = $this->get_service_php();
 		$services = array_merge(
 			$this->get_service_db(),
-			isset( $php['depends_on']['memcached'] )
+			isset( $php['php']['depends_on']['memcached'] )
 				? $this->get_service_memcached()
 				: $this->get_service_redis(),
 			$php,

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -255,7 +255,7 @@ class Docker_Compose_Generator {
 	protected function get_service_db() : array {
 		return [
 			'db' => [
-				'image' => $this->args['db-image'],
+				'image' => $this->get_config()['db-image'],
 				'container_name' => "{$this->project_name}-db",
 				'volumes' => [
 					'db-data:/var/lib/mysql',
@@ -607,6 +607,7 @@ class Docker_Compose_Generator {
 			'kibana' => true,
 			'xray' => true,
 			'ignore-paths' => [],
+			'db-image' => 'biarms/mysql:5.7',
 		];
 
 		return array_merge( $defaults, $local_server, $local_vip );

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -172,6 +172,8 @@ class Docker_Compose_Generator {
 			$services['depends_on']['redis'] = [
 				'condition' => 'service_started',
 			];
+			$services['environment']['REDIS_HOST'] = 'redis';
+			$services['environment']['REDIS_PORT'] = 6379;
 		}
 
 		if ( $this->get_config()['elasticsearch'] ) {

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -80,6 +80,27 @@ class Docker_Compose_Generator {
 	 * @return array
 	 */
 	protected function get_php_reusable() : array {
+		$version_map = [
+			'8.0' => 'humanmade/altis-local-server-php:5.0.0-beta.1',
+			'7.4' => 'humanmade/altis-local-server-php:4.2.0',
+		];
+
+		$versions = array_keys( $version_map );
+		$version = (string) $this->get_config()['php'];
+
+		if ( ! in_array( $version, $versions, true ) ) {
+			echo sprintf(
+				"The configured PHP version \"%s\" is not supported.\nTry one of the following:\n  - %s\n",
+				// phpcs:ignore HM.Security.EscapeOutput.OutputNotEscaped
+				$version,
+				// phpcs:ignore HM.Security.EscapeOutput.OutputNotEscaped
+				implode( "\n  - ", $versions )
+			);
+			exit( 1 );
+		}
+
+		$image = $version_map[ $version ];
+
 		$services = [
 			'init' => true,
 			'depends_on' => [
@@ -93,7 +114,7 @@ class Docker_Compose_Generator {
 					'condition' => 'service_started',
 				],
 			],
-			'image' => 'humanmade/altis-local-server-php:4.2.0',
+			'image' => $image,
 			'links' => [
 				'db:db-read-replica',
 			],

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -81,7 +81,9 @@ class Docker_Compose_Generator {
 	 */
 	protected function get_php_reusable() : array {
 		$version_map = [
-			'8.0' => 'humanmade/altis-local-server-php:5.0.0',
+			'8.2' => 'humanmade/altis-local-server-php:8.2.8',
+			'8.1' => 'humanmade/altis-local-server-php:6.0.10',
+			'8.0' => 'humanmade/altis-local-server-php:5.0.10',
 			'7.4' => 'humanmade/altis-local-server-php:4.2.0',
 		];
 

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -255,7 +255,7 @@ class Docker_Compose_Generator {
 	protected function get_service_db() : array {
 		return [
 			'db' => [
-				'image' => 'biarms/mysql:5.7',
+				'image' => $this->args['db-image'],
 				'container_name' => "{$this->project_name}-db",
 				'volumes' => [
 					'db-data:/var/lib/mysql',

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -29,8 +29,11 @@ function bootstrap() {
 	} else if ( is_subdomain_install() ) {
 		define( 'SUBDOMAIN_INSTALL', 1 );
 
-		// Configure PECL Memcached integration to load on a very early hook.
-		add_action( 'enable_wp_debug_mode_checks', __NAMESPACE__ . '\\load_object_cache_memcached' );
+		// Some environments may use Redis instead, so load Memcached conditionally.
+		if ( class_exists( 'Memcached' ) ) {
+			// Configure PECL Memcached integration to load on a very early hook.
+			add_action( 'enable_wp_debug_mode_checks', __NAMESPACE__ . '\\load_object_cache_memcached' );
+		}
 	}
 
 	defined( 'DB_HOST' ) or define( 'DB_HOST', getenv( 'DB_HOST' ) );

--- a/project-root/wp-config.php
+++ b/project-root/wp-config.php
@@ -73,9 +73,18 @@ foreach ( $required_constants as $constant ) {
 }
 
 // Set up global to enable the memcached connection.
+// This is only used by PHP 7.4 images.
 global $memcached_servers;
 // "memcached" is the hostname of the relevant network container.
 $memcached_servers = [ [ 'memcached', 11211 ] ];
+
+// Set up global to enable redis connection.
+// This is only used by PHP 8+ images.
+global $redis_server;
+$redis_server = [
+	'host' => getenv( 'REDIS_HOST' ),
+	'port' => getenv( 'REDIS_PORT' ),
+];
 
 // Load VIP configuration and constants.
 if ( is_readable( WP_CONTENT_DIR . '/vip-config/vip-config.php' ) ) {


### PR DESCRIPTION
A (now-reverted) change to `composer-2` added support for PHP 8.0, but I neglected to realize that the image used for PHP 8 removes memcached support in favor of Redis, causing actual uses of this package to break. This PR resolves that issue by replacing memcached with Redis if a non-supporting image is selected. Although this takes it would of parity with VIP (which uses Memcached in it's production infrastructure) it does allow the local dev environment to run on PHP 8.